### PR TITLE
feat(web-sdk): 支持验证码文案国际化

### DIFF
--- a/tianai-captcha-web-sdk/src/captcha/concat/concat.js
+++ b/tianai-captcha-web-sdk/src/captcha/concat/concat.js
@@ -10,7 +10,7 @@ function getTemplate(styleConfig) {
     return `
     <div id="tianai-captcha" class="tianai-captcha-slider tianai-captcha-concat">
     <div class="slider-tip">
-        <span id="tianai-captcha-slider-move-track-font" >拖动滑块完成拼图</span>
+        <span id="tianai-captcha-slider-move-track-font" style="font-size: ${styleConfig.i18n.concat_title_size}">${styleConfig.i18n.concat_title}</span>
     </div>
     <div class="content">
         <div class="tianai-captcha-slider-concat-img-div" id="tianai-captcha-slider-concat-img-div">

--- a/tianai-captcha-web-sdk/src/captcha/config/config.js
+++ b/tianai-captcha-web-sdk/src/captcha/config/config.js
@@ -144,24 +144,25 @@ class CaptchaConfig {
         }).then(res => {
             if (res.code == 200) {
                 const useTimes = (data.stopTime - data.startTime) / 1000;
-                c.showTips(`验证成功,耗时${useTimes}秒`, 1, () => this.validSuccess(res, c, tac));
+                c.showTips(c.styleConfig.i18n.tips_success.replace("%s", useTimes), 1, () => this.validSuccess(res, c, tac));
             } else {
-                let tipMsg = "验证失败，请重新尝试!";
+                let tipMsg = c.styleConfig.i18n.tips_error;
                 if (res.code) {
                     if (res.code != 4001) {
-                        tipMsg = "验证码被黑洞吸走了！";
+                        tipMsg = c.styleConfig.i18n.tips_4001;
                     }
                 }
                 c.showTips(tipMsg, 0, () => this.validFail(res, c, tac));
             }
         }).catch(e => {
+            const errorResponse = e || {};
             let tipMsg = c.styleConfig.i18n.tips_error;
-            if (e.code && e.code != 200) {
-                if (res.code != 4001) {
+            if (errorResponse.code && errorResponse.code != 200) {
+                if (errorResponse.code != 4001) {
                     tipMsg = c.styleConfig.i18n.tips_4001;
                 }
-                c.showTips(tipMsg, 0, () => this.validFail(res, c, tac));
             }
+            c.showTips(tipMsg, 0, () => this.validFail(errorResponse, c, tac));
         })
 
     }

--- a/tianai-captcha-web-sdk/src/captcha/config/styleConfig.js
+++ b/tianai-captcha-web-sdk/src/captcha/config/styleConfig.js
@@ -9,15 +9,20 @@ export default {
     i18n: {
         tips_success: "验证成功,耗时%s秒",
         tips_error : "验证失败，请重新尝试!",
+        tips_4001: "验证码被黑洞吸走了！",
+        interface_error: "接口异常",
         slider_title:"拖动滑块完成拼图",
         concat_title: "拖动滑块完成拼图",
         image_click_title: "请依次点击:",
         rotate_title: "拖动滑块完成拼图",
+        disable_title: "验证码不可用",
+        click_confirm_btn: "确定",
         // TITLE 大小
         slider_title_size:"15px",
         concat_title_size: "15px",
         image_click_title_size: "20px",
         rotate_title_size: "15px",
+        disable_title_size: "15px",
     }
 
 }

--- a/tianai-captcha-web-sdk/src/captcha/disable/disable.js
+++ b/tianai-captcha-web-sdk/src/captcha/disable/disable.js
@@ -51,7 +51,7 @@ class Disable {
         }
     }
     loadCaptchaForData (that, data) {
-        const msg = data.msg || data.message || "接口异常";
+        const msg = data.msg || data.message || that.styleConfig.i18n.interface_error;
         that.el.find("#content-span").text(msg);
     }
 }

--- a/tianai-captcha-web-sdk/src/captcha/image_click/image_click.js
+++ b/tianai-captcha-web-sdk/src/captcha/image_click/image_click.js
@@ -21,7 +21,7 @@ function getTemplate(styleConfig) {
         </div>
          <div class="tianai-captcha-tips" id="tianai-captcha-tips"></div>
     </div>
-    <div class="click-confirm-btn">确定</div>
+    <div class="click-confirm-btn">${styleConfig.i18n.click_confirm_btn}</div>
 </div>
 `;
 }


### PR DESCRIPTION
## 变更说明
- 为 TAC Web SDK 补充可配置的 `i18n` 文案字段。
- 将拼图滑块、点选确认按钮、禁用态提示、校验成功/失败提示中的硬编码中文改为读取 `styleConfig.i18n`。
- 保持默认中文文案不变，不影响现有使用方式。

## 测试
- 已执行 `npm run buildprod`，构建通过。